### PR TITLE
Add ulimit parameter to docker run commands in workflows

### DIFF
--- a/.github/workflows/broker-build-test.yml
+++ b/.github/workflows/broker-build-test.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           go-version: "1.22"
 
+      - name: Set up Terraform latest
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
       - name: Checkout generator
         uses: actions/checkout@v4
         with:
@@ -61,12 +66,6 @@ jobs:
         run: |
           echo "No changes detected, skipping further steps"          
 
-      - name: List changed files - from now on all tests are run only if there were changes
-        if: steps.check-changed-files.outputs.files_changed == 'true'
-        run: |
-          echo "Changed files: ${{ steps.check-changed-files.outputs.changed_files }}"
-          git diff
-
       - name: Setup Test broker
         if: steps.check-changed-files.outputs.files_changed == 'true'
         run: |
@@ -75,11 +74,11 @@ jobs:
             --env system_scaling_maxconnectioncount="1000" --mount type=bind,source=$HOME/solace,destination=/var/lib/solace,ro=false solace/solace-pubsub-standard:latest
           while ! curl -s localhost:8080 | grep aurelia ; do sleep 1 ; done
 
-      - name: Set up Terraform latest
+      - name: List changed files - from now on all tests are run only if there were changes
         if: steps.check-changed-files.outputs.files_changed == 'true'
-        uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_wrapper: false
+        run: |
+          echo "Changed files: ${{ steps.check-changed-files.outputs.changed_files }}"
+          git diff
 
       - name: Test module from template on test broker
         if: steps.check-changed-files.outputs.files_changed == 'true'

--- a/.github/workflows/broker-build-test.yml
+++ b/.github/workflows/broker-build-test.yml
@@ -62,34 +62,37 @@ jobs:
           echo "No changes detected, skipping further steps"          
 
       - name: List changed files - from now on all tests are run only if there were changes
-        # if: steps.check-changed-files.outputs.files_changed == 'true'
+        if: steps.check-changed-files.outputs.files_changed == 'true'
         run: |
           echo "Changed files: ${{ steps.check-changed-files.outputs.changed_files }}"
           git diff
 
-      - name: Set up Terraform latest
-        # if: steps.check-changed-files.outputs.files_changed == 'true'
-        uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_wrapper: false
-
       - name: Setup Test broker
-        # if: steps.check-changed-files.outputs.files_changed == 'true'
+        if: steps.check-changed-files.outputs.files_changed == 'true'
         run: |
           mkdir -p $HOME/solace; chmod 777 $HOME/solace
           docker run -d -p 8080:8080 -p 55555:55555 --shm-size=1g --env username_admin_globalaccesslevel=admin --env username_admin_password=admin --env system_scaling_maxkafkabridgecount="10" --name=solace \
             --env system_scaling_maxconnectioncount="1000" --mount type=bind,source=$HOME/solace,destination=/var/lib/solace,ro=false solace/solace-pubsub-standard:latest
           while ! curl -s localhost:8080 | grep aurelia ; do sleep 1 ; done
 
+      - name: Set up Terraform latest
+        if: steps.check-changed-files.outputs.files_changed == 'true'
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_wrapper: false
+
       - name: Test module from template on test broker
+        if: steps.check-changed-files.outputs.files_changed == 'true'
         run: |
           ci/scripts/test-module.sh ci/template-test
 
       - name: Test module root on test broker
+        if: steps.check-changed-files.outputs.files_changed == 'true'
         run: |
           ci/scripts/test-module.sh ci/module-test
 
       - name: Test examples
+        if: steps.check-changed-files.outputs.files_changed == 'true'
         run: |
           shopt -s extglob
           for d in examples/!(basic-client-username)/; do (ci/scripts/test-module.sh "$d"); done

--- a/.github/workflows/broker-build-test.yml
+++ b/.github/workflows/broker-build-test.yml
@@ -71,6 +71,7 @@ jobs:
         run: |
           mkdir -p $HOME/solace; chmod 777 $HOME/solace
           docker run -d -p 8080:8080 -p 55555:55555 --shm-size=1g --env username_admin_globalaccesslevel=admin --env username_admin_password=admin --env system_scaling_maxkafkabridgecount="10" --name=solace \
+            --ulimit nofile=1048576:1048576 \
             --env system_scaling_maxconnectioncount="1000" --mount type=bind,source=$HOME/solace,destination=/var/lib/solace,ro=false solace/solace-pubsub-standard:latest
           while ! curl -s localhost:8080 | grep aurelia ; do sleep 1 ; done
 

--- a/.github/workflows/module-test-pipeline-main-branch-only.yml
+++ b/.github/workflows/module-test-pipeline-main-branch-only.yml
@@ -13,18 +13,18 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
-      - name: Set up Terraform latest - with token
-        uses: hashicorp/setup-terraform@v3
-        with:
-          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
-          terraform_wrapper: true
-
       - name: Setup test broker
         run: |
           mkdir -p $HOME/solace; chmod 777 $HOME/solace
           docker run -d -p 8080:8080 -p 55555:55555 --shm-size=1g --env username_admin_globalaccesslevel=admin --env username_admin_password=admin --env system_scaling_maxkafkabridgecount="10" --name=solace \
             --env system_scaling_maxconnectioncount="1000" --mount type=bind,source=$HOME/solace,destination=/var/lib/solace,ro=false solace/solace-pubsub-standard:latest
           while ! curl -s localhost:8080 | grep aurelia ; do sleep 1 ; done
+
+      - name: Set up Terraform latest - with token
+        uses: hashicorp/setup-terraform@v3
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+          terraform_wrapper: true
 
       - name: Test module root on test broker
         run: |

--- a/.github/workflows/module-test-pipeline-main-branch-only.yml
+++ b/.github/workflows/module-test-pipeline-main-branch-only.yml
@@ -17,6 +17,7 @@ jobs:
         run: |
           mkdir -p $HOME/solace; chmod 777 $HOME/solace
           docker run -d -p 8080:8080 -p 55555:55555 --shm-size=1g --env username_admin_globalaccesslevel=admin --env username_admin_password=admin --env system_scaling_maxkafkabridgecount="10" --name=solace \
+            --ulimit nofile=1048576:1048576 \
             --env system_scaling_maxconnectioncount="1000" --mount type=bind,source=$HOME/solace,destination=/var/lib/solace,ro=false solace/solace-pubsub-standard:latest
           while ! curl -s localhost:8080 | grep aurelia ; do sleep 1 ; done
 

--- a/.github/workflows/module-test-pipeline.yml
+++ b/.github/workflows/module-test-pipeline.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           mkdir -p $HOME/solace; chmod 777 $HOME/solace
           docker run -d -p 8080:8080 -p 55555:55555 --shm-size=1g --env username_admin_globalaccesslevel=admin --env username_admin_password=admin --env system_scaling_maxkafkabridgecount="10" --name=solace \
+            --ulimit nofile=1048576:1048576 \
             --env system_scaling_maxconnectioncount="1000" --mount type=bind,source=$HOME/solace,destination=/var/lib/solace,ro=false solace/solace-pubsub-standard:latest
           while ! curl -s localhost:8080 | grep aurelia ; do sleep 1 ; done
 

--- a/.github/workflows/prep-internal-release.yml
+++ b/.github/workflows/prep-internal-release.yml
@@ -43,6 +43,7 @@ jobs:
         run: |
           mkdir -p $HOME/solace; chmod 777 $HOME/solace
           docker run -d -p 8080:8080 -p 55555:55555 --shm-size=1g --env username_admin_globalaccesslevel=admin --env username_admin_password=admin --env system_scaling_maxkafkabridgecount="10" --name=solace \
+            --ulimit nofile=1048576:1048576 \
             --env system_scaling_maxconnectioncount="1000" --mount type=bind,source=$HOME/solace,destination=/var/lib/solace,ro=false solace/solace-pubsub-standard:latest
           while ! curl -s localhost:8080 | grep aurelia ; do sleep 1 ; done
 

--- a/.github/workflows/verify-registry-release.yml
+++ b/.github/workflows/verify-registry-release.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           mkdir -p $HOME/solace; chmod 777 $HOME/solace
           docker run -d -p 8080:8080 -p 55555:55555 --shm-size=1g --env username_admin_globalaccesslevel=admin --env username_admin_password=admin --env system_scaling_maxkafkabridgecount="10" --name=solace \
+            --ulimit nofile=1048576:1048576 \
             --env system_scaling_maxconnectioncount="1000" --mount type=bind,source=$HOME/solace,destination=/var/lib/solace,ro=false solace/solace-pubsub-standard:latest
           while ! curl -s localhost:8080 | grep aurelia ; do sleep 1 ; done
 


### PR DESCRIPTION
## Summary
- Added --ulimit nofile=1048576:1048576 to all docker run commands
- This increases the file descriptor limit for Solace broker containers
- Applied to all 5 workflow files containing docker run commands

## Details
This change adds the ulimit parameter to configure the maximum number of open file descriptors for the Solace broker containers in our GitHub Actions workflows. The increased limit (1048576) ensures the broker can handle higher loads and prevents potential issues related to file descriptor exhaustion.

## Modified Files
- .github/workflows/broker-build-test.yml
- .github/workflows/module-test-pipeline-main-branch-only.yml
- .github/workflows/module-test-pipeline.yml
- .github/workflows/prep-internal-release.yml
- .github/workflows/verify-registry-release.yml

🤖 Generated with Claude Code